### PR TITLE
Insert Namespace & Directory Project Validation

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -1,6 +1,7 @@
 {
   "name": "OsmiKit",
   "version": "0.0.1",
+  "osmiVersion":  "1.0.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/src/commands/generate.js
+++ b/src/commands/generate.js
@@ -1,6 +1,5 @@
 const { p, command, heading, warning, direction } = require("../tools/pretty")
 const { map, pipe, values } = require('ramda')
-const fs = require('fs')
 
 const availableGenerator = [{
   name: 'component',
@@ -106,68 +105,72 @@ module.exports = {
       table,
       colors: { bold, yellow, muted, white },
     } = print
+    let setting;
+    try {
+      setting = require(process.cwd()+'/package.json')
+      if(setting.osmiVersion){
+        if (parameters.first) {
+          const generator = parameters.first.toLowerCase()
 
-    // Check if current directory is osmi project base
-    if(fs.existsSync(process.cwd()+'/osmi.lock')){
-      if (parameters.first) {
-        const generator = parameters.first.toLowerCase()
-
-        // check if generate command is exists
-        const commandExists = availableGenerator.find(command => command.name === generator)
-        if (!commandExists) {
-          return await generateCommandNotAvailable(toolbox)
-        }
-
-        // we need a name for this component
-        const name = parameters.second
-        if (!name) {
-          return warning(`⚠️  Please specify a name for your ${parameters.first}: osmi g ${parameters.first} MyName`)
-        }
-
-        // avoid the my-component-component phenomenon
-        const pascalGenerator = strings.pascalCase(generator)
-
-        let pascalName = strings.pascalCase(name)
-        if (pascalName.endsWith(pascalGenerator)) {
-          p(`Stripping ${pascalGenerator} from end of name`)
-          p(
-            `Note that you don't need to add ${pascalGenerator} to the end of the name -- we'll do it for you!`,
-          )
-          pascalName = pascalName.slice(0, -1 * pascalGenerator.length)
-          command(`osmi generate ${generator} ${pascalName}`)
-        }
-
-        switch (parameters.first) {
-          case "container":
-            await generateContainer(pascalName, parameters.second, toolbox)
-            break;
-
-          case "component":
-            await generateComponent(pascalName, parameters.second, toolbox)
-            break;
-
-          case "redux":
-            await generateRedux(pascalName, parameters.second, toolbox)
-            break;
-
-          case "saga":
-            await generateSaga(pascalName, parameters.second, toolbox)
-            break;
-
-          default:
+          // check if generate command is exists
+          const commandExists = availableGenerator.find(command => command.name === generator)
+          if (!commandExists) {
             return await generateCommandNotAvailable(toolbox)
+          }
+
+          // we need a name for this component
+          const name = parameters.second
+          if (!name) {
+            return warning(`⚠️  Please specify a name for your ${parameters.first}: osmi g ${parameters.first} MyName`)
+          }
+
+          // avoid the my-component-component phenomenon
+          const pascalGenerator = strings.pascalCase(generator)
+
+          let pascalName = strings.pascalCase(name)
+          if (pascalName.endsWith(pascalGenerator)) {
+            p(`Stripping ${pascalGenerator} from end of name`)
+            p(
+              `Note that you don't need to add ${pascalGenerator} to the end of the name -- we'll do it for you!`,
+            )
+            pascalName = pascalName.slice(0, -1 * pascalGenerator.length)
+            command(`osmi generate ${generator} ${pascalName}`)
+          }
+
+          switch (parameters.first) {
+            case "container":
+              await generateContainer(pascalName, parameters.second, toolbox)
+              break;
+
+            case "component":
+              await generateComponent(pascalName, parameters.second, toolbox)
+              break;
+
+            case "redux":
+              await generateRedux(pascalName, parameters.second, toolbox)
+              break;
+
+            case "saga":
+              await generateSaga(pascalName, parameters.second, toolbox)
+              break;
+
+            default:
+              return await generateCommandNotAvailable(toolbox)
+          }
+        } else {
+          warning('⚠️  No generators detected.')
+          p()
+          heading('Generator allow you to quickly make frequently created files such as:')
+          p("* Container")
+          p("* Components")
+          p("* Redux")
+          p("* Saga")
         }
       } else {
-        warning('⚠️  No generators detected.')
-        p()
-        heading('Generator allow you to quickly make frequently created files such as:')
-        p("* Container")
-        p("* Components")
-        p("* Redux")
-        p("* Saga")
+        warning('⚠️ Oopss, you can not generate something to outside root directory project of osmi')
       }
-    } else {
-      warning('⚠️ Oopss, this directory is not osmi project base or osmi.lock is not found')
+    } catch (err) {
+      warning('⚠️ Oopss, you can not generate something to outside root directory project of osmi')
     }
   }
 }

--- a/src/commands/generate.js
+++ b/src/commands/generate.js
@@ -1,5 +1,6 @@
 const { p, command, heading, warning, direction } = require("../tools/pretty")
 const { map, pipe, values } = require('ramda')
+const fs = require('fs')
 
 const availableGenerator = [{
   name: 'component',
@@ -15,62 +16,70 @@ const availableGenerator = [{
   description: 'Generates a saga.',
 }]
 
-const generateContainer = async (name, toolbox) => {
+/***
+ *
+ * @param name (is module or class name for template)
+ * @param filename (is a filename)
+ * @param toolbox
+ * @returns {Promise<void>}
+ */
+
+const generateContainer = async (name, filename,toolbox) => {
   const { print, template: { generate } } = toolbox
 
   await generate({
     template: 'container.ejs',
-    target: `App/Containers/${name}.js`,
+    target: `App/Containers/${filename}.js`,
     props: { name }
   })
-  print.info(`${print.checkmark} App/Containers/${name}.js`)
+  print.info(`${print.checkmark} App/Containers/${filename}.js`)
 
   await generate({
     template: 'styles.ejs',
-    target: `App/Containers/Styles/${name}Style.js`,
+    target: `App/Containers/Styles/${filename}Style.js`,
     props: { name }
   })
-  print.info(`${print.checkmark} App/Containers/Styles/${name}Style.js`)
+  print.info(`${print.checkmark} App/Containers/Styles/${filename}Style.js`)
 }
 
-const generateComponent = async (name, toolbox) => {
+const generateComponent = async (name, filename, toolbox) => {
   const { print, template: { generate } } = toolbox
 
   await generate({
     template: 'component.ejs',
-    target: `App/Components/${name}.js`,
+    target: `App/Components/${filename}.js`,
     props: { name }
   })
-  print.info(`${print.checkmark} App/Components/${name}.js`)
+  print.info(`${print.checkmark} App/Components/${filename}.js`)
 
   await generate({
     template: 'styles.ejs',
-    target: `App/Components/Styles/${name}Style.js`,
+    target: `App/Components/Styles/${filename}Style.js`,
     props: { name }
   })
-  print.info(`${print.checkmark} App/Components/Styles/${name}Style.js`)
+  print.info(`${print.checkmark} App/Components/Styles/${filename}Style.js`)
 }
 
-const generateRedux = async (name, toolbox) => {
+const generateRedux = async (name, filename, toolbox) => {
   const { print, template: { generate } } = toolbox
 
   await generate({
     template: 'redux.ejs',
-    target: `App/Redux/${name}Redux.js`,
+    target: `App/Redux/${filename}Redux.js`,
     props: { name }
   })
-  print.info(`${print.checkmark} App/Redux/${name}Redux.js`)
+  print.info(`${print.checkmark} App/Redux/${filename}Redux.js`)
 }
 
-const generateSaga = async (name, toolbox) => {
+const generateSaga = async (name, filename, toolbox) => {
   const { print, template: { generate } } = toolbox
 
   await generate({
     template: 'saga.ejs',
-    target: `App/Sagas/${name}Sagas.js`,
+    target: `App/Sagas/${filename}Sagas.js`,
     props: { name }
   })
-  print.info(`${print.checkmark} App/Sagas/${name}Sagas.js`)
+  print.info(`${print.checkmark} App/Sagas/${filename}Sagas.js`)
 }
 
 const generateCommandNotAvailable = async toolbox => {
@@ -98,61 +107,67 @@ module.exports = {
       colors: { bold, yellow, muted, white },
     } = print
 
-    if (parameters.first) {
-      const generator = parameters.first.toLowerCase()
+    // Check if current directory is osmi project base
+    if(fs.existsSync(process.cwd()+'/osmi.lock')){
+      if (parameters.first) {
+        const generator = parameters.first.toLowerCase()
 
-      // check if generate command is exists
-      const commandExists = availableGenerator.find(command => command.name === generator)
-      if (!commandExists) {
-        return await generateCommandNotAvailable(toolbox)
-      }
-
-      // we need a name for this component
-      const name = parameters.second
-      if (!name) {
-        return warning(`⚠️  Please specify a name for your ${parameters.first}: osmi g ${parameters.first} MyName`)
-      }
-
-      // avoid the my-component-component phenomenon
-      const pascalGenerator = strings.pascalCase(generator)
-      let pascalName = strings.pascalCase(name)
-      if (pascalName.endsWith(pascalGenerator)) {
-        p(`Stripping ${pascalGenerator} from end of name`)
-        p(
-          `Note that you don't need to add ${pascalGenerator} to the end of the name -- we'll do it for you!`,
-        )
-        pascalName = pascalName.slice(0, -1 * pascalGenerator.length)
-        command(`osmi generate ${generator} ${pascalName}`)
-      }
-
-      switch (parameters.first) {
-        case "container":
-          await generateContainer(pascalName, toolbox)
-          break;
-
-        case "component":
-          await generateComponent(pascalName, toolbox)
-          break;
-
-        case "redux":
-          await generateRedux(pascalName, toolbox)
-          break;
-
-        case "saga":
-          await generateSaga(pascalName, toolbox)
-          break;
-
-        default:
+        // check if generate command is exists
+        const commandExists = availableGenerator.find(command => command.name === generator)
+        if (!commandExists) {
           return await generateCommandNotAvailable(toolbox)
+        }
+
+        // we need a name for this component
+        const name = parameters.second
+        if (!name) {
+          return warning(`⚠️  Please specify a name for your ${parameters.first}: osmi g ${parameters.first} MyName`)
+        }
+
+        // avoid the my-component-component phenomenon
+        const pascalGenerator = strings.pascalCase(generator)
+
+        let pascalName = strings.pascalCase(name)
+        if (pascalName.endsWith(pascalGenerator)) {
+          p(`Stripping ${pascalGenerator} from end of name`)
+          p(
+            `Note that you don't need to add ${pascalGenerator} to the end of the name -- we'll do it for you!`,
+          )
+          pascalName = pascalName.slice(0, -1 * pascalGenerator.length)
+          command(`osmi generate ${generator} ${pascalName}`)
+        }
+
+        switch (parameters.first) {
+          case "container":
+            await generateContainer(pascalName, parameters.second, toolbox)
+            break;
+
+          case "component":
+            await generateComponent(pascalName, parameters.second, toolbox)
+            break;
+
+          case "redux":
+            await generateRedux(pascalName, parameters.second, toolbox)
+            break;
+
+          case "saga":
+            await generateSaga(pascalName, parameters.second, toolbox)
+            break;
+
+          default:
+            return await generateCommandNotAvailable(toolbox)
+        }
+      } else {
+        warning('⚠️  No generators detected.')
+        p()
+        heading('Generator allow you to quickly make frequently created files such as:')
+        p("* Container")
+        p("* Components")
+        p("* Redux")
+        p("* Saga")
       }
     } else {
-      warning('⚠️  No generators detected.')
-      p()
-      heading('Generator allow you to quickly make frequently created files such as:')
-      p("* Container")
-      p("* Components")
-      p("* Redux")
-      p("* Saga")
+      warning('⚠️ Oopss, this directory is not osmi project base or osmi.lock is not found')
     }
   }
 }

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -1,3 +1,4 @@
+const fs = require('fs')
 const { spawnProgress } = require("../tools/spawn")
 const { p, heading, command, direction, osmiHeading } = require("../tools/pretty")
 
@@ -32,6 +33,10 @@ module.exports = {
     const cliString = `npx react-native init ${projectName} --template file://${osmiPath}${
       debug ? " --verbose" : ""
     }`
+
+    const lockFile = () => fs.writeFileSync(process.cwd()+'/'+projectName+'/osmi.lock', '')
+
+
 
     log({ cli, osmiPath, boilerplatePath, cliString })
 
@@ -111,7 +116,7 @@ module.exports = {
 
     // we're done! round performance stats to .xx digits
     const perfDuration = Math.round((new Date().getTime() - perfStart) / 10) / 100
-
+    lockFile()
     p()
     heading(`${yellow("Osmi CLI")} initializing ${yellow(projectName)} in ${gray(`${perfDuration}s`)}`)
     p()

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -1,4 +1,3 @@
-const fs = require('fs')
 const { spawnProgress } = require("../tools/spawn")
 const { p, heading, command, direction, osmiHeading } = require("../tools/pretty")
 
@@ -34,7 +33,6 @@ module.exports = {
       debug ? " --verbose" : ""
     }`
 
-    const lockFile = () => fs.writeFileSync(process.cwd()+'/'+projectName+'/osmi.lock', '')
 
 
 
@@ -116,7 +114,6 @@ module.exports = {
 
     // we're done! round performance stats to .xx digits
     const perfDuration = Math.round((new Date().getTime() - perfStart) / 10) / 100
-    lockFile()
     p()
     heading(`${yellow("Osmi CLI")} initializing ${yellow(projectName)} in ${gray(`${perfDuration}s`)}`)
     p()


### PR DESCRIPTION
This PR contain enhancement to validating current directory project and create namespace for generator function.

# How its work ?

When user generating something on own project (eg: component or container), cli must know this current project is osmi base project or not. When current project or current directory is a not osmi base project, cli not able to create a file because is not a directory.

Sometime user need to create namespace to specify a same type of module or container to one directory, in this PR i updating current code base to able do that.