### PR TITLE
Fix minor bugs style & babel plugin

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -48,6 +48,7 @@
     "@babel/runtime": "^7.12.5",
     "@react-native-community/eslint-config": "^2.0.0",
     "babel-jest": "^26.6.3",
+    "babel-plugin-ignite-ignore-reactotron": "^0.3.0"
     "eslint": "^7.17.0",
     "jest": "^26.6.3",
     "metro-react-native-babel-preset": "^0.64.0",

--- a/src/templates/component.ejs
+++ b/src/templates/component.ejs
@@ -3,7 +3,7 @@ import React, { memo } from 'react'
 import { View, Text } from 'react-native'
 
 // Styles
-import styles from './Styles/TestStyle'
+import styles from './Styles/<%= props.name %>Style'
 import { apply } from '../Themes/OsmiProvider'
 
 const <%= props.name %> = props => {


### PR DESCRIPTION
- Change import styles from `TestStyle` to `<%= props.name %>Style'<%= props.name %>Style`
- fix error "Cannot find module 'babel-plugin-ignite-ignore-reactotron' when build release android by adding dev dependencies `babel-plugin-ignite-ignore-reactotron`"